### PR TITLE
update multiple links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,36 @@ Campfire is an open-source, self-hosted deploy preview solution that spins up de
 Campfire integrates a feedback interface directly into each deploy preview, allowing teams to collaborate efficiently on proposed code changes or bug fixes from the early stages of development. All user interactions are synced bidirectionally with the associated GitHub pull request. For more detailed insights, please refer to our [full case study](#).
 
 ## Features
+
 - **Automated Deploy Previews** - For each pull request, Campfire automatically generates a deploy preview accessible via a public URL.
 - **Integrated Feedback Interface** - Enables direct user feedback within the deploy preview, synchronized with GitHub pull requests issue comments for seamless collaboration.
 - **Session Replay** - Captures user interactions within the deploy preview to aid in debugging and understanding user experiences.
 
 ## System Requirements
+
 Campfire supports front-end applications that meet the following criteria:
+
 - Hosted on GitHub.
 - Include a Dockerfile.
 - Operate independently of a backend or interact with an external backend via APIs.
 
 ## Architecture
+
 Campfire leverages several technologies:
+
 - **GitHub Actions** - Automates the deployment of deploy previews.
 - **AWS ECS** - Hosts the deploy previews in a scalable, containerized environment.
 - **AWS Lambda** - Manages backend functionalities including GitHub API interactions and AWS services, reducing server management overhead.
 - **AWS S3** - Stores session replay data and other user-generated content, ensuring data is easily accessible and securely managed.
 
 ## Getting Started
-To start using Campfire, follow the setup instructions in our [installation guide](#). Campfire's CLI tool facilitates easy configuration and management of the deploy environment.
 
-You can also view a [demo version of Campfire here](#).
+To start using Campfire, follow the setup instructions in our [installation guide](https://github.com/campfire-previews/campfire-cli#readme). Campfire's CLI tool facilitates easy configuration and management of the deploy environment.
+
+You can also view a 45 second demo of Campfire [here](https://campfire-previews.github.io/).
 
 ## Future Enhancements
+
 - **CSS Editor** - Allow users to suggest and apply CSS changes directly within the deploy preview.
 - **Screenshot Functionality** - Enable capturing specific moments within the deploy preview for easy sharing and documentation.
 - **GitHub User Authorization** - Streamline user identification by linking comments directly to GitHub accounts.
@@ -39,10 +46,10 @@ You can also view a [demo version of Campfire here](#).
 
 ## Campfire Team
 
-[Allen Lee](#) • Software Engineer • Leonia, NJ
+[Allen Lee](https://a.llenlee.com/) • Software Engineer • Leonia, NJ
 
-[Rachele Lang](#) • Software Engineer • Denver, CO
+[Rachele Lang](https://ramlang.github.io/) • Software Engineer • Denver, CO
 
-[Tess Lockey](#) • Software Engineer • Las Vegas, NV
+[Tess Lockey](https://tesslockey.com/) • Software Engineer • Las Vegas, NV
 
 [Weston Ludeke](https://westonludeke.github.io) • Software Engineer • Houston, TX


### PR DESCRIPTION
The following links were updated: installation guide link to CLI readme, demo link to case study, and Campfire team links to personal sites.